### PR TITLE
게시글 작성, 수정 페이지 분리

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -76,7 +76,7 @@ class Api {
         const config: RequestInit = {
           ...init,
           headers: {
-            ...init?.headers,
+            ...init?.headers
           }
         };
         return fetch(`${this.apiUrl}${input}`, config);
@@ -137,9 +137,14 @@ class Api {
   }
 
   updatePost(postId: number, payload: UpdatePostData) {
-    return this.fetchJson<void>(`/posts/${postId}`, {
+    console.log(payload);
+    return this.fetchDate(`/posts/${postId}`, {
       method: 'PATCH',
-      body: JSON.stringify(payload)
+      body: JSON.stringify(payload),
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      credentials: 'include'
     });
   }
 
@@ -149,13 +154,13 @@ class Api {
 
   postLike(postId: number) {
     return this.fetchJson<PostLike>(`/posts/like/${postId}`, {
-      credentials: 'include',
+      credentials: 'include'
     });
   }
 
   postLikeCheck(postId: number) {
     return this.fetchJson<PostLikeCheck>(`/posts/like-check/${postId}`, {
-      credentials: 'include',
+      credentials: 'include'
     });
   }
 
@@ -172,7 +177,13 @@ class Api {
   }
 
   writeComment(payload: WriteCommentData) {
-    return this.fetchJson<void>('/comments', { method: 'POST', body: JSON.stringify(payload) })
+    return this.fetchJson<void>('/comments', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    });
   }
 
   getCommentList(postId: number) {
@@ -192,6 +203,9 @@ class Api {
     return this.fetchDate('/users', {
       method: 'POST',
       body: JSON.stringify(payload),
+      headers: {
+        'Content-Type': 'application/json'
+      }
     });
   }
 
@@ -200,6 +214,9 @@ class Api {
       method: 'POST',
       credentials: 'include',
       body: JSON.stringify(payload),
+      headers: {
+        'Content-Type': 'application/json'
+      }
     });
   }
 
@@ -218,7 +235,7 @@ class Api {
   uploadImage(form: FormData) {
     return this.fetchJson<UploadedImage>('/file/upload', {
       method: 'POST',
-      body: form,
+      body: form
     });
   }
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -76,7 +76,6 @@ class Api {
         const config: RequestInit = {
           ...init,
           headers: {
-            'Content-Type': 'application/json',
             ...init?.headers,
           }
         };
@@ -109,7 +108,14 @@ class Api {
   }
 
   writerPost(payload: WritePostData) {
-    return this.init().post('/posts', payload);
+    return this.fetchDate('/posts', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    });
   }
 
   getPostList() {
@@ -212,7 +218,7 @@ class Api {
   uploadImage(form: FormData) {
     return this.fetchJson<UploadedImage>('/file/upload', {
       method: 'POST',
-      body: form
+      body: form,
     });
   }
 

--- a/src/components/Detail.tsx
+++ b/src/components/Detail.tsx
@@ -34,6 +34,7 @@ const Detail = ({ post }: DetailProps) => (
       writer={post.writer.nickname}
       thumbnail={post.thumbnail}
       publicScope={post.publicScope}
+      categoryName={post.category.categoryName}
       createAt={stringToDate(post.createAt)}
     />
     <PostLike postId={post.id} />

--- a/src/components/PostContent.tsx
+++ b/src/components/PostContent.tsx
@@ -13,6 +13,7 @@ interface PostContentProps {
   createAt: Date;
   writer: string;
   thumbnail: string;
+  categoryName: string;
 }
 
 const Container = styled.div`
@@ -80,6 +81,7 @@ const PostContent = ({
   writer,
   thumbnail,
   publicScope,
+  categoryName,
   createAt
 }: PostContentProps) => {
   const navigate = useNavigate();
@@ -105,7 +107,8 @@ const PostContent = ({
                     introduction,
                     thumbnail,
                     content,
-                    publicScope
+                    publicScope,
+                    categoryName
                   }
                 })
               }

--- a/src/pages/EditPostPage.tsx
+++ b/src/pages/EditPostPage.tsx
@@ -2,7 +2,7 @@ import MDEditor, { ContextStore } from '@uiw/react-md-editor';
 import React, { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
-import UploadPostPage from './UploadPostPage';
+// import UploadPostPage from './UploadPostPage';
 
 type MDEditorOnChange = (
   value?: string,
@@ -40,22 +40,22 @@ const BackButton = styled.button`
   border-radius: 12px;
 `;
 
-const PostingButton = styled.button`
-  padding: 1rem 2rem;
-  border: 0.5px solid lightgray;
-  font-size: 1.4rem;
-  font-weight: 700;
-  color: white;
-  background-color: powderblue;
-  border-radius: 12px;
-`;
+// const PostingButton = styled.button`
+//   padding: 1rem 2rem;
+//   border: 0.5px solid lightgray;
+//   font-size: 1.4rem;
+//   font-weight: 700;
+//   color: white;
+//   background-color: powderblue;
+//   border-radius: 12px;
+// `;
 
 const EditPostPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const {id, content, title, introduction, thumbnail, publicScope} = location.state;
+  const {content} = location.state;
   const [text, setText] = useState(content);
-  const [uploadModalVisible, setUploadModalVisible] = useState(false);
+  // const [uploadModalVisible, setUploadModalVisible] = useState(false);
 
   const onClick: MDEditorOnChange = (
     value?: string,
@@ -66,17 +66,13 @@ const EditPostPage = () => {
 
   return (
     <Container>
-      {uploadModalVisible && (
+      {/* TODO 새로운 uploadModal로 변경 */}
+      {/* {uploadModalVisible && (
         <UploadPostPage
-          id={id}
-          title={title}
           content={text}
-          introduction={introduction}
-          thumbnail={thumbnail}
-          publicScope={publicScope}
           setModalVisible={setUploadModalVisible}
         />
-      )}
+      )} */}
       <EdittorBlock>
         <MDEditor
           className="editor"
@@ -88,7 +84,7 @@ const EditPostPage = () => {
         />
         <ButtonBlock>
           <BackButton onClick={() => navigate(-1)}>뒤로 가기</BackButton>
-          <PostingButton onClick={() => setUploadModalVisible(true)}>수정하기</PostingButton>
+          {/* <PostingButton onClick={() => setUploadModalVisible(true)}>수정하기</PostingButton> */}
         </ButtonBlock>
       </EdittorBlock>
       {/* <MDEditor.Markdown source={value} style={{ whiteSpace: "pre-wrap" }} /> */}

--- a/src/pages/WritePostPage.tsx
+++ b/src/pages/WritePostPage.tsx
@@ -1,8 +1,10 @@
 import MDEditor, { ContextStore } from '@uiw/react-md-editor';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 import UploadPostPage from './UploadPostPage';
+import api from '../api/api';
+import { SimpleCategory } from '../type';
 
 type MDEditorOnChange = (
   value?: string,
@@ -54,9 +56,27 @@ const PostingButton = styled.button`
 
 const WritePostPage = () => {
   const navigate = useNavigate();
-  // const [isDragOn, setIsDragOn] = useState(false);
   const [text, setText] = useState('**Hello world!!!**');
   const [uploadModalVisible, setUploadModalVisible] = useState(false);
+  const [categoryList, setCategoryList] = useState<SimpleCategory[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      const categories = (await api.getCategoryList()).result!;
+      const tmpList: SimpleCategory[] = [];
+      // depth가 있는 카테고리 평탄화
+      categories.forEach((c) => {
+        tmpList.push({ id: c.id, categoryName: c.categoryName });
+
+        if (c.childCategories.length >= 1) {
+          c.childCategories.forEach((cc) =>
+            tmpList.push({ id: cc.id, categoryName: cc.categoryName })
+          );
+        }
+      });
+      setCategoryList(tmpList);
+    })();
+  }, []);
 
   const onClick: MDEditorOnChange = (
     value?: string,
@@ -71,20 +91,19 @@ const WritePostPage = () => {
       {uploadModalVisible && (
         <UploadPostPage
           content={text}
+          categoryList={categoryList}
           setModalVisible={setUploadModalVisible}
         />
       )}
       <EdittorBlock>
-          <MDEditor
-            
-            className='editor'
-            value={text}
-            onChange={onClick}
-            preview='live'
-            fullscreen
-            height={500}
-            
-          />
+        <MDEditor
+          className='editor'
+          value={text}
+          onChange={onClick}
+          preview='live'
+          fullscreen
+          height={500}
+        />
         <ButtonBlock>
           <BackButton
             onClick={() => {

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -6,7 +6,7 @@ export interface PostPreview {
   createAt: string;
   likes: number;
   commentCount: number;
-};
+}
 
 export interface User {
   id: number;
@@ -27,7 +27,18 @@ export interface Post {
   writer: Writer;
   thumbnail: string;
   likes: number;
-  comments: Comment[]
+  comments: Comment[];
+  category: { categoryName: string };
+}
+
+export interface PostForUpdate {
+  id: number;
+  title: string;
+  content: string;
+  introduction: string;
+  publicScope: 'PUBLIC' | 'PRIVATE';
+  thumbnail: string;
+  categoryName: string;
 }
 
 interface Writer {
@@ -69,7 +80,7 @@ export interface ValidateLogin {
   id: number;
   email: string;
   role: 'USER' | 'ADMIN';
-};
+}
 
 export interface UploadedImage {
   filePath: string;
@@ -87,4 +98,4 @@ export interface ErrorResponse {
   error: string;
   message: string;
   statusCode: number;
-};
+}

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -51,6 +51,11 @@ export interface Category {
   childCategories: Category[] | [];
 }
 
+export interface SimpleCategory {
+  id: number;
+  categoryName: string;
+}
+
 export interface OtherPost {
   id: number;
   title: string;


### PR DESCRIPTION
## 🐘 작업 내용
- 게시글 업로드 화면과 수정 후 업로드 화면을 분리
- 업로드 화면의 대부분의 코드가 유사하지만 타입이 모호해져서 일단은 분리

## 기타
- 추후에 컴포넌트를 나눠 리팩토링할 예정
